### PR TITLE
platformVersion: Add fallback for rolling release linux distros

### DIFF
--- a/lib/util/build_info.dart
+++ b/lib/util/build_info.dart
@@ -47,7 +47,7 @@ class BuildInfo {
     else if (_p.isLinux) {
       final info = await DeviceInfoPlugin().linuxInfo;
       deviceModel = info.name;
-      platformVersion = info.versionId!;
+      platformVersion = info.versionId ?? _p.version;
     } else if (_p.isMacOS) {
       final info = await DeviceInfoPlugin().macOsInfo;
       deviceModel = info.model;


### PR DESCRIPTION
On rolling release based Linux distros (at least on ArchLinux) getting the platform version from `info.versionId` fails. Looks like getting it from `_p.version`  is a meaningful fallback. On my system this prop contains Linux kernel version and build time  which gives you some idea about the system.