### PR TITLE
Replace hard-coded 'https://tudo.cachapa.net' while sharing and editing lists

### DIFF
--- a/lib/common/edit_list.dart
+++ b/lib/common/edit_list.dart
@@ -210,7 +210,7 @@ class _MemberList extends StatelessWidget {
 
   void _inviteMember(BuildContext context) {
     final t = context.t;
-    final shareUrl = 'https://tudo.cachapa.net/list/${list.id}';
+    final shareUrl = '${Registry.settingsProvider.serverUri}/list/${list.id}';
 
     showDialog(
       context: context,

--- a/lib/common/share_list.dart
+++ b/lib/common/share_list.dart
@@ -5,6 +5,7 @@ import 'package:share_plus/share_plus.dart';
 
 import '../extensions.dart';
 import '../lists/list_provider.dart';
+import '../registry.dart';
 
 void shareToDoList(BuildContext context, ToDoList list) {
   showModalBottomSheet<String>(
@@ -19,7 +20,7 @@ void shareToDoList(BuildContext context, ToDoList list) {
 class _ShareListForm extends StatelessWidget {
   final ToDoList list;
 
-  String get shareUrl => 'https://tudo.cachapa.net/list/${list.id}';
+  String get shareUrl => '${Registry.settingsProvider.serverUri}/list/${list.id}';
 
   const _ShareListForm({required this.list});
 


### PR DESCRIPTION
First of all, I loooooooooove your app! I was trying to build exactly that but a mix of life, a lack of time, sleep and - most probably - ability made me advance very slowly. I was still on it, but then I stumbled upon your app. What a revelation! I stopped working on mine immediately. How beautifully solved!

Thank you so much for this! :clap::clap::clap: 

Okay, praise aside, I just realized that the share URI was hard-coded. I think this commit should solve this. Although I'm not sure it is the correct way to read the settings.

I'll be glad to change whatever you think necessary. And needless to say, you can change whatever if you feel like it too.

Again, thank you very much! :heart: